### PR TITLE
Admins::StaticPages 作成

### DIFF
--- a/app/assets/stylesheets/admins/static_pages.scss
+++ b/app/assets/stylesheets/admins/static_pages.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Admins::StaticPages controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admins/sessions_controller.rb
+++ b/app/controllers/admins/sessions_controller.rb
@@ -25,12 +25,12 @@ class Admins::SessionsController < Devise::SessionsController
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
 
-  #ログイン後のリダイレクト先
+  # ログイン後のリダイレクト先
   def after_sign_in_path_for(resource)
     admins_dashboard_path
   end
 
-  #ログアウト後のリダイレクト先
+  # ログアウト後のリダイレクト先
   def after_sign_out_path_for(resource)
     new_admin_session_path
   end

--- a/app/controllers/admins/sessions_controller.rb
+++ b/app/controllers/admins/sessions_controller.rb
@@ -24,4 +24,14 @@ class Admins::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  #ログイン後のリダイレクト先
+  def after_sign_in_path_for(resource)
+    admins_dashboard_path
+  end
+
+  #ログアウト後のリダイレクト先
+  def after_sign_out_path_for(resource)
+    new_admin_session_path
+  end
 end

--- a/app/controllers/admins/static_pages_controller.rb
+++ b/app/controllers/admins/static_pages_controller.rb
@@ -1,0 +1,12 @@
+class Admins::StaticPagesController < ApplicationController
+  before_action :admin_user
+
+  def dashboard
+  end
+
+  protected
+
+  def admin_user
+    redirect_to new_admin_session_url unless admin_signed_in?
+  end
+end

--- a/app/helpers/admins/static_pages_helper.rb
+++ b/app/helpers/admins/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module Admins::StaticPagesHelper
+end

--- a/app/views/admins/static_pages/dashboard.html.erb
+++ b/app/views/admins/static_pages/dashboard.html.erb
@@ -1,0 +1,2 @@
+<h1>Admins::StaticPages#dashboard</h1>
+<p>Find me in app/views/admins/static_pages/dashboard.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :admins do
+    get '/dashboard', to: 'static_pages#dashboard'
+  end
   devise_for :admins, :controllers => {
     sessions: 'admins/sessions',
   }

--- a/spec/requests/admins/sessions_request_spec.rb
+++ b/spec/requests/admins/sessions_request_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Sessions", type: :request do
       end
 
       it "リダイレクトすること" do
-        expect(response).to redirect_to root_url
+        expect(response).to redirect_to admins_dashboard_url
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe "Sessions", type: :request do
 
     it "リダイレクトされること" do
       delete destroy_admin_session_url
-      expect(response).to redirect_to root_url
+      expect(response).to redirect_to new_admin_session_url
     end
   end
 end

--- a/spec/requests/admins/static_pages_request_spec.rb
+++ b/spec/requests/admins/static_pages_request_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Admins::StaticPages", type: :request do
         sign_in admin
         get admins_dashboard_url
       end
+
       it "リクエストが成功すること" do
         expect(response.status).to eq 200
       end
@@ -18,6 +19,7 @@ RSpec.describe "Admins::StaticPages", type: :request do
       before do
         get admins_dashboard_url
       end
+
       it "リクエストが成功すること" do
         expect(response.status).to eq 302
       end
@@ -27,5 +29,4 @@ RSpec.describe "Admins::StaticPages", type: :request do
       end
     end
   end
-
 end

--- a/spec/requests/admins/static_pages_request_spec.rb
+++ b/spec/requests/admins/static_pages_request_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "Admins::StaticPages", type: :request do
+  let!(:admin) { create(:admin) }
+
+  describe "GET /dashboard" do
+    context "ログインしているとき" do
+      before do
+        sign_in admin
+        get admins_dashboard_url
+      end
+      it "リクエストが成功すること" do
+        expect(response.status).to eq 200
+      end
+    end
+
+    context "ログインしていないとき" do
+      before do
+        get admins_dashboard_url
+      end
+      it "リクエストが成功すること" do
+        expect(response.status).to eq 302
+      end
+
+      it "リダイレクトされること" do
+        expect(response).to redirect_to new_admin_session_url
+      end
+    end
+  end
+
+end

--- a/spec/system/admins/sessions_spec.rb
+++ b/spec/system/admins/sessions_spec.rb
@@ -21,8 +21,9 @@ RSpec.feature "Admin::Sessions", type: :system do
     click_button "ログイン"
     expect(page).to have_content "ログインしました。"
     expect(page).to have_selector "a.nav-link", text: "ログアウト"
+    expect(current_path).to eq admins_dashboard_path
     click_link "ログアウト"
     expect(page).to have_content "ログアウトしました。"
-    expect(current_path).to eq root_path
+    expect(current_path).to eq new_admin_session_path
   end
 end


### PR DESCRIPTION
以下、実装いたしました。

・rails g controller Admins::StaticPages でコントローラ・ビューなどを自動生成。
・上記コントローラ・ビューにて dashboard アクション・ビューを作成。
・dashboard は、adminでログインした人しか訪問できないよう、before_action でログイン判定を設定。
・adminユーザーのログイン後のリダイレクト先を、root から admins_dashboard_path に変更
・adminユーザーのログアウト後のリダイレクト先を、root から new_admin_sessions_path に変更
・上記に関連するテストの作成および更新